### PR TITLE
Enhanced definition of LNS targets for Routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Postgres running on localhost at port 5432.
 #### `test`
 
 `test` is the environment where `mix test` runs. It is assumed to have
-Postgress running on localhost at port 5432.
+Postgres running on localhost at port 5432.
 
 #### `prod`
 

--- a/lib/helium_config/core/gwmp_lns.ex
+++ b/lib/helium_config/core/gwmp_lns.ex
@@ -1,0 +1,8 @@
+defmodule HeliumConfig.Core.GwmpLns do
+  @moduledoc """
+
+  Core representation of a LoRaWan network server that supports GWMP.
+
+  """
+  defstruct [:host, :port]
+end

--- a/lib/helium_config/core/helium_router_lns.ex
+++ b/lib/helium_config/core/helium_router_lns.ex
@@ -1,0 +1,10 @@
+defmodule HeliumConfig.Core.HeliumRouterLns do
+  @moduledoc """
+
+  Core representation of a Helium Router instance as an LoRaWan
+  network server.
+
+  """
+
+  defstruct [:host, :port]
+end

--- a/lib/helium_config/core/helium_router_lns.ex
+++ b/lib/helium_config/core/helium_router_lns.ex
@@ -1,7 +1,7 @@
 defmodule HeliumConfig.Core.HeliumRouterLns do
   @moduledoc """
 
-  Core representation of a Helium Router instance as an LoRaWan
+  Core representation of a Helium Router instance as a LoRaWan
   network server.
 
   """

--- a/lib/helium_config/core/http_roaming_lns.ex
+++ b/lib/helium_config/core/http_roaming_lns.ex
@@ -1,0 +1,9 @@
+defmodule HeliumConfig.Core.HttpRoamingLns do
+  @moduledoc """
+
+  Core representation of a LoRaWAN network server that supports HTTP roaming.
+
+  """
+
+  defstruct [:host, :port, :auth_header, :dedupe_window]
+end

--- a/lib/helium_config/core/lns.ex
+++ b/lib/helium_config/core/lns.ex
@@ -1,0 +1,108 @@
+defmodule HeliumConfig.Core.Lns do
+  @moduledoc """
+  Utility functions for converting Core LNS models to and from JSON and DB representations.
+  """
+  alias HeliumConfig.Core
+  alias HeliumConfig.DB
+
+  def from_proto({:http_roaming, proto}) do
+    %Core.HttpRoamingLns{
+      host: proto.ip,
+      port: proto.port
+    }
+  end
+
+  def from_proto({:gwmp, proto}) do
+    %Core.GwmpLns{
+      host: proto.ip,
+      port: proto.port
+    }
+  end
+
+  def from_proto({:helium_router, proto}) do
+    %Core.HeliumRouterLns{
+      host: proto.ip,
+      port: proto.port
+    }
+  end
+
+  def from_web(json = %{"type" => "http_roaming"}) do
+    json
+    |> Enum.reduce(
+      %Core.HttpRoamingLns{},
+      fn
+        {"type", _}, roaming ->
+          roaming
+
+        {"host", host}, roaming ->
+          Map.put(roaming, :host, host)
+
+        {"port", port}, roaming ->
+          Map.put(roaming, :port, port)
+
+        {"dedupe_window", window}, roaming ->
+          Map.put(roaming, :dedupe_window, window)
+
+        {"auth_header", header}, roaming ->
+          Map.put(roaming, :auth_header, header)
+      end
+    )
+  end
+
+  def from_web(json = %{"type" => "gwmp"}) do
+    json
+    |> Enum.reduce(
+      %Core.GwmpLns{},
+      fn
+        {"type", _}, gwmp ->
+          gwmp
+
+        {"host", host}, gwmp ->
+          Map.put(gwmp, :host, host)
+
+        {"port", port}, gwmp ->
+          Map.put(gwmp, :port, port)
+      end
+    )
+  end
+
+  def from_web(json = %{"type" => "helium_router"}) do
+    json
+    |> Enum.reduce(
+      %Core.HeliumRouterLns{},
+      fn
+        {"type", _}, gwmp ->
+          gwmp
+
+        {"host", host}, gwmp ->
+          Map.put(gwmp, :host, host)
+
+        {"port", port}, gwmp ->
+          Map.put(gwmp, :port, port)
+      end
+    )
+  end
+
+  def from_db(lns = %DB.Lns{type: :http_roaming}) do
+    %Core.HttpRoamingLns{
+      host: lns.host,
+      port: lns.port,
+      dedupe_window: Map.get(lns.protocol_params, "dedupe_window"),
+      auth_header: Map.get(lns.protocol_params, "auth_header")
+    }
+  end
+
+  def from_db(lns = %DB.Lns{type: :gwmp}) do
+    %Core.GwmpLns{
+      host: lns.host,
+      port: lns.port
+    }
+  end
+
+  def from_db(lns = %DB.Lns{type: :helium_router}) do
+    %Core.HeliumRouterLns{
+      host: lns.host,
+      port: lns.port
+    }
+  end
+end

--- a/lib/helium_config/db/lns.ex
+++ b/lib/helium_config/db/lns.ex
@@ -1,0 +1,97 @@
+defmodule HeliumConfig.DB.Lns do
+  @moduledoc """
+  This is a database representation of a LoRaWAN network server.
+
+  The HeliumConfig.Core data model has three kinds of LNS:
+  HttpRoamingLns, GwmpLns, and HeliumRouterLns.  This schema allows us
+  to store the three types in the same database table under a
+  normalized format.  The `type` field indicates which kind it is.
+  The `protocol_params` field holds a map containing LNS type-specific
+  options, and the remaining fields, like 'host' and 'port', are common
+  to all LNS implementations.
+
+  """
+
+  use Ecto.Schema
+
+  import Ecto.Changeset
+
+  defmodule LnsType do
+    @moduledoc false
+
+    use Ecto.Type
+    def type, do: :string
+
+    def cast(term), do: {:ok, term}
+
+    def load("http_roaming"), do: {:ok, :http_roaming}
+    def load("gwmp"), do: {:ok, :gwmp}
+    def load("helium_router"), do: {:ok, :helium_router}
+    def load(_), do: :error
+
+    def dump(:http_roaming), do: Ecto.Type.dump(:string, "http_roaming")
+    def dump(:gwmp), do: Ecto.Type.dump(:string, "gwmp")
+    def dump(:helium_router), do: Ecto.Type.dump(:string, "helium_router")
+    def dump(_), do: :error
+  end
+
+  alias HeliumConfig.Core.GwmpLns
+  alias HeliumConfig.Core.HeliumRouterLns
+  alias HeliumConfig.Core.HttpRoamingLns
+
+  schema "route_lns" do
+    belongs_to :route, HeliumConfig.DB.Route
+    field :type, __MODULE__.LnsType
+    field :host, :string
+    field :port, :integer
+    field :protocol_params, :map
+
+    timestamps()
+  end
+
+  def changeset(lns, fields \\ %{})
+
+  def changeset(lns = %__MODULE__{}, roaming = %HttpRoamingLns{}) do
+    roaming_params =
+      %{}
+      |> Map.put("auth_header", roaming.auth_header)
+      |> Map.put("dedupe_window", roaming.dedupe_window)
+
+    lns_params =
+      %{}
+      |> Map.put(:type, :http_roaming)
+      |> Map.put(:host, roaming.host)
+      |> Map.put(:port, roaming.port)
+      |> Map.put(:protocol_params, roaming_params)
+
+    changeset(lns, lns_params)
+  end
+
+  def changeset(lns = %__MODULE__{}, roaming = %GwmpLns{}) do
+    lns_params = %{
+      type: :gwmp,
+      host: roaming.host,
+      port: roaming.port,
+      protocol_params: %{}
+    }
+
+    changeset(lns, lns_params)
+  end
+
+  def changeset(lns = %__MODULE__{}, roaming = %HeliumRouterLns{}) do
+    lns_params = %{
+      type: :helium_router,
+      host: roaming.host,
+      port: roaming.port,
+      protocol_params: %{}
+    }
+
+    changeset(lns, lns_params)
+  end
+
+  def changeset(lns = %__MODULE__{}, fields) do
+    lns
+    |> cast(fields, [:type, :host, :port, :protocol_params])
+    |> validate_required([:type, :host, :port])
+  end
+end

--- a/lib/helium_config/db/route.ex
+++ b/lib/helium_config/db/route.ex
@@ -10,6 +10,7 @@ defmodule HeliumConfig.DB.Route do
   alias HeliumConfig.Core.Route, as: CoreRoute
   alias HeliumConfig.DB.DevaddrRange
   alias HeliumConfig.DB.EUI
+  alias HeliumConfig.DB.Lns
   alias HeliumConfig.DB.Organization
 
   defmodule ProtocolType do
@@ -35,8 +36,8 @@ defmodule HeliumConfig.DB.Route do
 
   schema "routes" do
     field :net_id, :integer
-    field :lns_address, :string
-    field :protocol, __MODULE__.ProtocolType
+
+    has_one :lns, Lns, on_replace: :delete
 
     has_many :euis,
              EUI,
@@ -58,8 +59,7 @@ defmodule HeliumConfig.DB.Route do
   def changeset(route = %__MODULE__{}, core_route = %CoreRoute{}) do
     fields = %{
       net_id: core_route.net_id,
-      lns_address: core_route.lns_address,
-      protocol: core_route.protocol,
+      lns: core_route.lns,
       euis: core_route.euis,
       devaddr_ranges:
         Enum.map(core_route.devaddr_ranges, fn {s, e} -> %{start_addr: s, end_addr: e} end)
@@ -70,8 +70,9 @@ defmodule HeliumConfig.DB.Route do
 
   def changeset(route = %__MODULE__{}, fields = %{}) do
     route
-    |> cast(fields, [:net_id, :lns_address, :protocol])
+    |> cast(fields, [:net_id])
     |> cast_assoc(:devaddr_ranges)
     |> cast_assoc(:euis)
+    |> cast_assoc(:lns)
   end
 end

--- a/lib/helium_config_grpc/views/route_view.ex
+++ b/lib/helium_config_grpc/views/route_view.ex
@@ -3,16 +3,42 @@ defmodule HeliumConfigGRPC.RouteView do
   Provides functions to convert HeliumConfig.Core.Route structs to maps suitable for encoding protobuf messages.
   """
 
+  alias HeliumConfig.Core.GwmpLns
+  alias HeliumConfig.Core.HeliumRouterLns
+  alias HeliumConfig.Core.HttpRoamingLns
   alias HeliumConfig.Core.Route
 
   def route_params(route = %Route{}) do
     %{
       net_id: route.net_id,
-      lns: route.lns_address,
-      protocol: route.protocol,
+      protocol: lns_params(route.lns),
       euis: Enum.map(route.euis, &eui_pair_params/1),
       devaddr_ranges: Enum.map(route.devaddr_ranges, &devaddr_range_params/1)
     }
+  end
+
+  def lns_params(%HttpRoamingLns{host: host, port: port}) do
+    {:http_roaming,
+     %{
+       ip: host,
+       port: port
+     }}
+  end
+
+  def lns_params(%GwmpLns{host: host, port: port}) do
+    {:gwmp,
+     %{
+       ip: host,
+       port: port
+     }}
+  end
+
+  def lns_params(%HeliumRouterLns{host: host, port: port}) do
+    {:router,
+     %{
+       ip: host,
+       port: port
+     }}
   end
 
   def eui_pair_params(pair = %{app_eui: _app, dev_eui: _dev}), do: pair

--- a/lib/helium_config_web/views/route_view.ex
+++ b/lib/helium_config_web/views/route_view.ex
@@ -1,6 +1,10 @@
 defmodule HeliumConfigWeb.RouteView do
   use HeliumConfigWeb, :view
 
+  alias HeliumConfig.Core.GwmpLns
+  alias HeliumConfig.Core.HeliumRouterLns
+  alias HeliumConfig.Core.HttpRoamingLns
+
   def render("routes.json", %{routes: routes}) do
     %{
       routes: Enum.map(routes, &route_json/1)
@@ -10,14 +14,37 @@ defmodule HeliumConfigWeb.RouteView do
   def route_json(route) do
     %{
       net_id: route.net_id,
-      lns_address: route.lns_address,
-      protocol: protocol_json(route.protocol),
+      lns: lns_json(route.lns),
       euis: route.euis,
       devaddr_ranges: Enum.map(route.devaddr_ranges, &devaddr_range_json/1)
     }
   end
 
-  def protocol_json(proto) when is_atom(proto), do: to_string(proto)
+  def lns_json(lns = %HttpRoamingLns{}) do
+    %{
+      type: "http_roaming",
+      host: lns.host,
+      port: lns.port,
+      auth_header: lns.auth_header,
+      dedupe_window: lns.dedupe_window
+    }
+  end
+
+  def lns_json(lns = %GwmpLns{}) do
+    %{
+      type: "gwmp",
+      host: lns.host,
+      port: lns.port
+    }
+  end
+
+  def lns_json(lns = %HeliumRouterLns{}) do
+    %{
+      type: "helium_router",
+      host: lns.host,
+      port: lns.port
+    }
+  end
 
   def devaddr_range_json({s, e}) do
     %{

--- a/mix.lock
+++ b/mix.lock
@@ -19,7 +19,7 @@
   "gettext": {:hex, :gettext, "0.20.0", "75ad71de05f2ef56991dbae224d35c68b098dd0e26918def5bb45591d5c8d429", [:mix], [], "hexpm", "1c03b177435e93a47441d7f681a7040bd2a816ece9e2666d1c9001035121eb3d"},
   "grpc": {:hex, :grpc, "0.5.0", "a44cb306625a52fa31a2189ce91b40d24e82569568f0cc214c1e1e0faf54f58a", [:mix], [{:cowboy, "~> 2.9", [hex: :cowboy, repo: "hexpm", optional: false]}, {:cowlib, "~> 2.11", [hex: :cowlib, repo: "hexpm", optional: false]}, {:gun, "~> 2.0.1", [hex: :grpc_gun, repo: "hexpm", optional: false]}], "hexpm", "17b98593fdb1a65be7b2722821266627b3f2fba29bbbd7d0945389427c0d0d5f"},
   "gun": {:hex, :grpc_gun, "2.0.1", "221b792df3a93e8fead96f697cbaf920120deacced85c6cd3329d2e67f0871f8", [:rebar3], [{:cowlib, "~> 2.11", [hex: :cowlib, repo: "hexpm", optional: false]}], "hexpm", "795a65eb9d0ba16697e6b0e1886009ce024799e43bb42753f0c59b029f592831"},
-  "helium_proto": {:git, "https://github.com/helium/proto.git", "c8ea861ece4f232cf6ddb837ed95deda8647299f", [branch: "macpie/packet_router"]},
+  "helium_proto": {:git, "https://github.com/helium/proto.git", "2ad7af0a48c7b613916ac2cff236d738f6d0b17d", [branch: "macpie/packet_router"]},
   "jason": {:hex, :jason, "1.3.0", "fa6b82a934feb176263ad2df0dbd91bf633d4a46ebfdffea0c8ae82953714946", [:mix], [{:decimal, "~> 1.0 or ~> 2.0", [hex: :decimal, repo: "hexpm", optional: true]}], "hexpm", "53fc1f51255390e0ec7e50f9cb41e751c260d065dcba2bf0d08dc51a4002c2ac"},
   "libp2p_crypto": {:git, "https://github.com/helium/libp2p-crypto.git", "a969bb7affc7d3fa1472aef80d736c467d3f6d45", []},
   "mime": {:hex, :mime, "2.0.2", "0b9e1a4c840eafb68d820b0e2158ef5c49385d17fb36855ac6e7e087d4b1dcc5", [:mix], [], "hexpm", "e6a3f76b4c277739e36c2e21a2c640778ba4c3846189d5ab19f97f126df5f9b7"},

--- a/priv/repo/migrations/20220930190833_add_route_lns_table.exs
+++ b/priv/repo/migrations/20220930190833_add_route_lns_table.exs
@@ -1,0 +1,20 @@
+defmodule HeliumConfig.Repo.Migrations.AddRouteLnsTable do
+  use Ecto.Migration
+
+  def change do
+    alter table("routes") do
+      remove :lns_address
+      remove :protocol
+    end
+
+    create table("route_lns") do
+      add :route_id, references(:routes, on_delete: :delete_all), primary_key: true
+      add :type, :string
+      add :host, :string
+      add :port, :integer
+      add :protocol_params, :map
+
+      timestamps()
+    end
+  end
+end

--- a/test/core/organization_test.exs
+++ b/test/core/organization_test.exs
@@ -1,6 +1,8 @@
 defmodule HeliumConfig.Core.OrganizationTest do
   use HeliumConfig.DataCase
 
+  alias HeliumConfig.Core.GwmpLns
+  alias HeliumConfig.Core.HttpRoamingLns
   alias HeliumConfig.Core.Organization
   alias HeliumConfig.Core.Route
   alias HeliumConfig.DB.Organization, as: DBOrg
@@ -42,8 +44,12 @@ defmodule HeliumConfig.Core.OrganizationTest do
     route_params = [
       %{
         net_id: 7,
-        lns_address: "a.testdomain.com",
-        protocol: :http,
+        lns: %HttpRoamingLns{
+          host: "a.testdomain.com",
+          port: 8080,
+          dedupe_window: 1200,
+          auth_header: "x-helium-auth"
+        },
         euis: [
           %{app_eui: 1, dev_eui: 2},
           %{app_eui: 3, dev_eui: 4}
@@ -61,8 +67,10 @@ defmodule HeliumConfig.Core.OrganizationTest do
       },
       %{
         net_id: 7,
-        lns_address: "b.testdomain.com",
-        protocol: :gwmp,
+        lns: %GwmpLns{
+          host: "b.testdomain.com",
+          port: 1234
+        },
         euis: [
           %{app_eui: 5, dev_eui: 6},
           %{app_eui: 7, dev_eui: 8}
@@ -103,8 +111,12 @@ defmodule HeliumConfig.Core.OrganizationTest do
       routes: [
         %Route{
           net_id: 7,
-          lns_address: "a.testdomain.com",
-          protocol: :http,
+          lns: %HttpRoamingLns{
+            host: "a.testdomain.com",
+            port: 8080,
+            dedupe_window: 1200,
+            auth_header: "x-helium-auth"
+          },
           euis: [
             %{app_eui: 1, dev_eui: 2},
             %{app_eui: 3, dev_eui: 4}
@@ -116,8 +128,10 @@ defmodule HeliumConfig.Core.OrganizationTest do
         },
         %Route{
           net_id: 7,
-          lns_address: "b.testdomain.com",
-          protocol: :gwmp,
+          lns: %GwmpLns{
+            host: "b.testdomain.com",
+            port: 1234
+          },
           euis: [
             %{app_eui: 5, dev_eui: 6},
             %{app_eui: 7, dev_eui: 8}

--- a/test/core/route_test.exs
+++ b/test/core/route_test.exs
@@ -7,8 +7,7 @@ defmodule HeliumConfig.Core.RouteTest do
     expected =
       MapSet.new([
         :net_id,
-        :lns_address,
-        :protocol,
+        :lns,
         :euis,
         :devaddr_ranges
       ])

--- a/test/helium_config_grpc/route_view_test.exs
+++ b/test/helium_config_grpc/route_view_test.exs
@@ -47,6 +47,9 @@ defmodule HeliumConfigGRPC.RouteViewTest do
       |> RouteV1.decode()
       |> CoreRoute.from_proto()
 
+    # RouteV1 does not yet support the `auth_header` and
+    # `dedupe_window` fields in an LNS.
+
     expected_lns =
       core_route
       |> Map.get(:lns)

--- a/test/helium_config_grpc/route_view_test.exs
+++ b/test/helium_config_grpc/route_view_test.exs
@@ -1,6 +1,8 @@
 defmodule HeliumConfigGRPC.RouteViewTest do
   use ExUnit.Case
 
+  alias HeliumConfig.Core.HttpRoamingLns
+
   alias HeliumConfig.Core.Route, as: CoreRoute
 
   alias HeliumConfigGRPC.RouteView
@@ -11,8 +13,12 @@ defmodule HeliumConfigGRPC.RouteViewTest do
     core_route =
       CoreRoute.new(%{
         net_id: 7,
-        lns_address: "lns1.testdomain.com",
-        protocol: :gwmp,
+        lns: %HttpRoamingLns{
+          host: "lns1.testdomain.com",
+          port: 8080,
+          dedupe_window: 1200,
+          auth_header: "x-helium-auth"
+        },
         euis: [
           %{
             app_eui: 87,
@@ -41,6 +47,14 @@ defmodule HeliumConfigGRPC.RouteViewTest do
       |> RouteV1.decode()
       |> CoreRoute.from_proto()
 
-    assert(decoded == core_route)
+    expected_lns =
+      core_route
+      |> Map.get(:lns)
+      |> Map.put(:auth_header, nil)
+      |> Map.put(:dedupe_window, nil)
+
+    expected = Map.put(core_route, :lns, expected_lns)
+
+    assert(decoded == expected)
   end
 end

--- a/test/helium_config_grpc/server_test.exs
+++ b/test/helium_config_grpc/server_test.exs
@@ -1,6 +1,8 @@
 defmodule HeliumConfigGRPC.ServerTest do
   use HeliumConfig.DataCase
 
+  alias HeliumConfig.Core.GwmpLns
+  alias HeliumConfig.Core.HttpRoamingLns
   alias HeliumConfig.Core.Organization
   alias HeliumConfig.Core.Route
   alias HeliumConfigGRPC.Stub
@@ -34,8 +36,12 @@ defmodule HeliumConfigGRPC.ServerTest do
           routes: [
             %{
               net_id: 1,
-              lns_address: "lns1.testdomain.com",
-              protocol: :http,
+              lns: %HttpRoamingLns{
+                host: "lns1.testdomain.com",
+                port: 4000,
+                dedupe_window: 2000,
+                auth_header: "x-helium-auth"
+              },
               euis: [
                 %{
                   dev_eui: 100,
@@ -56,8 +62,10 @@ defmodule HeliumConfigGRPC.ServerTest do
           routes: [
             %{
               net_id: 2,
-              lns_address: "lns2.testdomain.com",
-              protocol: :http,
+              lns: %GwmpLns{
+                host: "lns2.testdomain.com",
+                port: 8888
+              },
               euis: [
                 %{
                   dev_eui: 300,

--- a/test/helium_config_test.exs
+++ b/test/helium_config_test.exs
@@ -93,6 +93,7 @@ defmodule HeliumConfig.HeliumConfigTest do
       assert([] == Repo.all(DB.Organization))
       assert([] == Repo.all(DB.Route))
       assert([] == Repo.all(DB.DevaddrRange))
+      assert([] == Repo.all(DB.Lns))
     end
   end
 
@@ -104,8 +105,12 @@ defmodule HeliumConfig.HeliumConfigTest do
       routes: [
         %{
           net_id: 7,
-          lns_address: "route1.testdomain.com",
-          protocol: :http,
+          lns: %Core.HttpRoamingLns{
+            host: "route1.testdomain.com",
+            port: 8000,
+            dedupe_window: 1200,
+            auth_header: "x-helium-auth"
+          },
           euis: [
             %{
               dev_eui: 100,

--- a/test/helium_config_web/controllers/organization_controller_test.exs
+++ b/test/helium_config_web/controllers/organization_controller_test.exs
@@ -24,8 +24,13 @@ defmodule HeliumConfigWeb.OrganizationControllerTest do
         "routes" => [
           %{
             "net_id" => 7,
-            "lns_address" => "lns1.testdomain.com",
-            "protocol" => "http",
+            "lns" => %{
+              "type" => "http_roaming",
+              "host" => "lns1.testdomain.com",
+              "port" => 8080,
+              "dedupe_window" => 1200,
+              "auth_header" => "x-auth-header"
+            },
             "euis" => [
               %{
                 "dev_eui" => 100,

--- a/test/helium_config_web/views/organization_view_test.exs
+++ b/test/helium_config_web/views/organization_view_test.exs
@@ -1,6 +1,7 @@
 defmodule HeliumConfigWeb.OrganizationViewTest do
   use ExUnit.Case
 
+  alias HeliumConfig.Core.HttpRoamingLns
   alias HeliumConfig.Core.Organization
   alias HeliumConfigWeb.OrganizationView
 
@@ -13,8 +14,12 @@ defmodule HeliumConfigWeb.OrganizationViewTest do
         routes: [
           %{
             net_id: 7,
-            lns_address: "lns1.testdomain.com",
-            protocol: :http,
+            lns: %HttpRoamingLns{
+              host: "lns1.testdomain.com",
+              port: 8080,
+              dedupe_window: 2000,
+              auth_header: "x-helium-auth"
+            },
             euis: ["eui1"],
             devaddr_ranges: [{0, 10}, {15, 20}]
           }
@@ -30,8 +35,13 @@ defmodule HeliumConfigWeb.OrganizationViewTest do
         routes: [
           %{
             net_id: 7,
-            lns_address: "lns1.testdomain.com",
-            protocol: "http",
+            lns: %{
+              type: "http_roaming",
+              host: "lns1.testdomain.com",
+              port: 8080,
+              dedupe_window: 2000,
+              auth_header: "x-helium-auth"
+            },
             euis: ["eui1"],
             devaddr_ranges: [
               %{

--- a/test/helium_config_web/views/route_view_test.exs
+++ b/test/helium_config_web/views/route_view_test.exs
@@ -1,6 +1,9 @@
 defmodule HeliumConfigWeb.RouteViewTest do
   use ExUnit.Case
 
+  alias HeliumConfig.Core.GwmpLns
+  alias HeliumConfig.Core.HeliumRouterLns
+  alias HeliumConfig.Core.HttpRoamingLns
   alias HeliumConfig.Core.Route, as: CoreRoute
   alias HeliumConfigWeb.RouteView
 
@@ -8,8 +11,12 @@ defmodule HeliumConfigWeb.RouteViewTest do
     core_route =
       CoreRoute.new(%{
         net_id: 7,
-        lns_address: "lns1.testdomain.com",
-        protocol: :gwmp,
+        lns: %HttpRoamingLns{
+          host: "lns1.testdomain.com",
+          port: 8080,
+          dedupe_window: 1000,
+          auth_header: "x-helium-auth"
+        },
         euis: [%{app_eui: 1, dev_eui: 2}],
         devaddr_ranges: [
           {1, 5},
@@ -43,6 +50,57 @@ defmodule HeliumConfigWeb.RouteViewTest do
       assert(
         %{start_addr: "00000001", end_addr: "0000000F"} = RouteView.devaddr_range_json({1, 15})
       )
+    end
+  end
+
+  describe "lns_json/1" do
+    test "returns the correct rendering of an HttpRoamingLns" do
+      expected = %{
+        type: "http_roaming",
+        host: "lns1.testdomain.com",
+        port: 8080,
+        dedupe_window: 5000,
+        auth_header: "x-helium-auth"
+      }
+
+      given = %HttpRoamingLns{
+        host: "lns1.testdomain.com",
+        port: 8080,
+        dedupe_window: 5000,
+        auth_header: "x-helium-auth"
+      }
+
+      assert(expected == RouteView.lns_json(given))
+    end
+
+    test "returns the correct rendering of a GwmpLns" do
+      expected = %{
+        type: "gwmp",
+        host: "lns2.testdomain.com",
+        port: 5555
+      }
+
+      given = %GwmpLns{
+        host: "lns2.testdomain.com",
+        port: 5555
+      }
+
+      assert(expected == RouteView.lns_json(given))
+    end
+
+    test "returns the correct rendering of a HeliumRouterLns" do
+      expected = %{
+        type: "helium_router",
+        host: "router.helium.com",
+        port: 4000
+      }
+
+      given = %HeliumRouterLns{
+        host: "router.helium.com",
+        port: 4000
+      }
+
+      assert(expected == RouteView.lns_json(given))
     end
   end
 end


### PR DESCRIPTION
This PR enhances the definition of the LNS targeted by a Route, allowing it to be defined as one of three possible types:

- `HeliumConfig.Core.HttpRoamingLns`
- `HeliumConfig.Core.GwmpLns`
- `HeliumConfig.Core.HeliumRouterLns`

## JSON API Changes

In the JSON API, `protocol` and `lns_address` fields are removed from the definition of a route and replaced with a single `lns` field, for example:

```bash
curl -X POST http://localhost:4000/api/v1/organizations \
 -H "content-type: application/json" \
 --data-binary @- <<EOF
{
  "organization": {
    "oui": 7,
    "owner_wallet_id": "owner_id",
    "payer_wallet_id": "payer_id",
    "routes": [
      {
        "net_id": 7,
        "lns": {
            "type": "http_roaming",
            "host": "lns1.testdomain.com",
            "port": 8080,
            "auth_header": "x-helium-auth",
            "dedupe_window": 1200
        },
.
.
.
```
The accepted values for `type` are `"http_roaming"`, `"gwmp"`, and `"helium_router"`.  The `"host"` and `"port"` fields are required for all LNS types.  The remaining fields are LNS type-specific.  For this PR, `"auth_header"` and `"dedupe_window"` are required when the type is `"http_roaming"`; `"gwmp"` and `"helium_router"` have no protocol specific fields.

## Database Changes

A new table, `route_lns` is created and the `:lns_address` and `:protocol` fields of `HeliumConfig.DB.Route` are replaced with a `has_one :lns, HeliumConfig.DB.Lns`.

`HeliumConfig.DB.Lns` is a schema containing these fields:
- `type`: a string indicating the LNS type, i.e. `"http_roaming"`, `"gwmp"`, or `"helium_router"`
- a number of fields common to all LNS types (such as `host` and `port`)
- `protocol_params`: a map containing fields specific to the LNS type

`HeliumConfig.DB.Lns.changeset/2` contains logic to convert the Core types, `HeliumConfig.Core.{HttpRoutingLns, GwmpLns, HeliumRouterLns}`, to appropriate changesets.  Also, `from_db/1` functions of the Core types are updated to convert `HeliumConfig.DB.Lns`.

## gRPC API Changes

The gRPC API is updated to conform to the latest version of `helium/proto` from the `macpie/packet_router` branch.  Specifically, this means the `lns` field is removed from `RouteV1` and the `protocol` field of `RouteV1` is now one of three possible types.  As of this version, they each contain only a `host` and `port` field; no protocol specific options are supported.
